### PR TITLE
Fix invalid syntax in Named_Entity_Recognition-LSTM-CNN-CRF-Tutorial.…

### DIFF
--- a/Named_Entity_Recognition-LSTM-CNN-CRF-Tutorial.ipynb
+++ b/Named_Entity_Recognition-LSTM-CNN-CRF-Tutorial.ipynb
@@ -1405,7 +1405,7 @@
     "                   use_gpu=use_gpu,\n",
     "                   char_to_ix=char_to_id,\n",
     "                   pre_word_embeds=word_embeds,\n",
-    "                   use_crf=parameters['crf']\n",
+    "                   use_crf=parameters['crf'],\n",
     "                   char_mode=parameters['char_mode'])\n",
     "print(\"Model Initialized!!!\")"
    ]


### PR DESCRIPTION
It will raise errors due to invalid syntax in Named_Entity_Recognition-LSTM-CNN-CRF-Tutorial.ipynb.